### PR TITLE
Allow user to supply delayMs option to capture helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The capture function takes three parameters: `capture(assert, identifier, option
 * `options`: An optional object with options. The following options are allowed:
   * `selector`: An optional selector to screenshot. If not specified, the whole page will be captured.
   * `fullPage`: If a full page screenshot should be made, or just the browsers viewport. Defaults to `true`.
+  * `delayMs`: Delay (in milliseconds) before taking the screenshot. Useful when you need to wait for CSS transitions, etc. Defaults to `100`.
   
 This works in both acceptance tests as well as in integration tests.
 

--- a/addon-test-support/helpers.js
+++ b/addon-test-support/helpers.js
@@ -1,7 +1,7 @@
 import { dasherize } from '@ember/string';
 import RSVP from 'rsvp';
 
-export async function capture(assert, fileName, { selector = null, fullPage = true } = {}) {
+export async function capture(assert, fileName, { selector = null, fullPage = true, delayMs = 100 } = {}) {
   let testId = assert.test.testId;
 
   let queryParamString = window.location.search.substr(1);
@@ -33,7 +33,7 @@ export async function capture(assert, fileName, { selector = null, fullPage = tr
   ];
 
   let url = `${window.location.protocol}//${window.location.host}${window.location.pathname}?${urlQueryParams.join('&')}`;
-  let response = await requestCapture(url, fileName, { selector, fullPage });
+  let response = await requestCapture(url, fileName, { selector, fullPage, delayMs });
 
   if (response.status === 'SUCCESS') {
     assert.ok(true, `visual-test: ${fileName} has not changed`);
@@ -59,7 +59,7 @@ export function prepareCaptureMode() {
   }
 }
 
-export async function requestCapture(url, fileName, { selector, fullPage }) {
+export async function requestCapture(url, fileName, { selector, fullPage, delayMs }) {
   // If not in capture mode, make a request to the middleware to capture a screenshot in node
   fileName = dasherize(fileName);
 
@@ -67,7 +67,8 @@ export async function requestCapture(url, fileName, { selector, fullPage }) {
     url,
     name: fileName,
     selector,
-    fullPage
+    fullPage,
+    delayMs
   };
 
   return await ajaxPost('/visual-test/make-screenshot', data, 'application/json');

--- a/index.js
+++ b/index.js
@@ -151,7 +151,7 @@ module.exports = {
     }
   },
 
-  _makeScreenshots: async function(url, fileName, { selector, fullPage }) {
+  _makeScreenshots: async function(url, fileName, { selector, fullPage, delayMs }) {
     let options = this.visualTest;
     let browser;
     try {
@@ -178,7 +178,7 @@ module.exports = {
     let screenshotOptions = { selector, fullPage };
 
     // To avoid problems...
-    await tab.wait(100);
+    await tab.wait(delayMs);
 
     // only if the file does not exist, or if we force to save, do we write the actual images themselves
     let newScreenshotUrl = null;
@@ -316,6 +316,7 @@ module.exports = {
       let fileName = this._getFileName(req.body.name);
       let selector = req.body.selector;
       let fullPage = req.body.fullPage || false;
+      let delayMs = req.body.delayMs ? parseInt(req.body.delayMs) : 100;
 
       if (fullPage === 'true') {
         fullPage = true;
@@ -325,7 +326,7 @@ module.exports = {
       }
 
       let data = {};
-      this._makeScreenshots(url, fileName, { selector, fullPage }).then(({ newBaseline, newScreenshotUrl }) => {
+      this._makeScreenshots(url, fileName, { selector, fullPage, delayMs }).then(({ newBaseline, newScreenshotUrl }) => {
         data.newScreenshotUrl = newScreenshotUrl;
         data.newBaseline = newBaseline;
         return this._compareImages(fileName);


### PR DESCRIPTION
This can be used on a case-by-case basis to allow for things like longer CSS transitions to complete.