### PR TITLE
Add ability to configure defaultDelayMs to control delay

### DIFF
--- a/addon-test-support/helpers.js
+++ b/addon-test-support/helpers.js
@@ -18,7 +18,8 @@ import RSVP from 'rsvp';
  * @param {Object} [options] An optional object with options. The following options are allowed:
  * @param {string} [options.selector] An optional selector to screenshot. If not specified, the whole page will be captured.
  * @param {boolean} [options.fullPage] If a full page screenshot should be made, or just the browsers viewport. Defaults to `true`
- * @param {integer} [options.delayMs] Delay (in milliseconds) before taking the screenshot. Useful when you need to wait for CSS transitions, etc. Defaults to `100`.
+ * @param {integer} [options.delayMs] Delay (in milliseconds) before taking the screenshot. Useful when you need to wait for CSS transitions, etc. Defaults to the configuration option `defaultDelayMs`.
+ *
  * @return {Promise}
  */
 export async function capture(assert, fileName, { selector = null, fullPage = true, delayMs = null } = {}) {

--- a/addon-test-support/helpers.js
+++ b/addon-test-support/helpers.js
@@ -21,7 +21,7 @@ import RSVP from 'rsvp';
  * @param {integer} [options.delayMs] Delay (in milliseconds) before taking the screenshot. Useful when you need to wait for CSS transitions, etc. Defaults to `100`.
  * @return {Promise}
  */
-export async function capture(assert, fileName, { selector = null, fullPage = true, delayMs = 100 } = {}) {
+export async function capture(assert, fileName, { selector = null, fullPage = true, delayMs = null } = {}) {
   let testId = assert.test.testId;
 
   let queryParamString = window.location.search.substr(1);

--- a/index.js
+++ b/index.js
@@ -31,7 +31,8 @@ module.exports = {
     chromePort: 0,
     windowWidth: 1024,
     windowHeight: 768,
-    noSandbox: false
+    noSandbox: false,
+    defaultDelayMs: 100
   },
 
   included(app) {
@@ -129,6 +130,10 @@ module.exports = {
     let options = this.visualTest;
     let tab;
 
+    if (!delayMs) {
+      delayMs = options.defaultDelayMs;
+    }
+
     try {
       tab = await this._getBrowserTab();
     } catch (e) {
@@ -146,8 +151,10 @@ module.exports = {
 
     let screenshotOptions = { selector, fullPage };
 
-    // To avoid problems...
-    await tab.wait(delayMs);
+    if (delayMs > 0) {
+      // To avoid problems...
+      await tab.wait(delayMs);
+    }
 
     // only if the file does not exist, or if we force to save, do we write the actual images themselves
     let newScreenshotUrl = null;
@@ -268,7 +275,7 @@ module.exports = {
       let fileName = this._getFileName(req.body.name);
       let selector = req.body.selector;
       let fullPage = req.body.fullPage || false;
-      let delayMs = req.body.delayMs ? parseInt(req.body.delayMs) : 100;
+      let delayMs = req.body.delayMs ? parseInt(req.body.delayMs) : null;
 
       if (fullPage === 'true') {
         fullPage = true;

--- a/tests/dummy/app/templates/docs/build.md
+++ b/tests/dummy/app/templates/docs/build.md
@@ -12,6 +12,7 @@ let app = new EmberAddon(defaults, {
    imgurClientId: null, // If set to a client ID of imgur, images will be uploaded there as well, to debug images e.g. on CI
    groupByOs: true, // If one set of images should be created/compared by OS
    noSandbox: false // This may need to be set to true depending on your environment e.g. in CI 
+   defaultDelayMs: 100 // Default delay between loading the page and taking the screenshot in milliseconds.
   }
 });
 ```


### PR DESCRIPTION
To control the delay before taking the screenshot.

I recently dealt with issues involving google-fonts loading slowly enough that many of our tests became flaky when fonts weren't loaded before capture. I eventually resolved this by moving the fonts into my project and serving them ourselves for testing, but controlling the default delay proved useful throughout the process. Also, I now am able to set the default delay to 0.