### PR TITLE
Approve command

### DIFF
--- a/lib/commands/approve.js
+++ b/lib/commands/approve.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const utils = require('../utils');
+const { runCommand, deleteImagesInFolder } = utils;
+const { resolve } = require('rsvp');
+const path = require('path');
+const fs = require('fs');
+
+module.exports = {
+  name: 'visual-test:approve',
+  aliases: ['vtr'],
+  description: 'Approve all changes - move changed images from tmp to baseline',
+  works: 'insideProject',
+  availableOptions: [
+    {
+      name: 'clear-tmp',
+      type: Boolean,
+      alias: 'ct',
+      default: true,
+      description: 'If the tmp/diff folders should be cleared first'
+    },
+    {
+      name: 'image-directory',
+      type: String,
+      alias: 'id',
+      default: 'visual-test-output/baseline',
+      description: 'The directory where the images are saved'
+    },
+    {
+      name: 'diff-directory',
+      type: String,
+      alias: 'diff',
+      default: 'visual-test-output/diff',
+      description: 'The directory where the diff images are saved'
+    },
+    {
+      name: 'tmp-directory',
+      type: String,
+      alias: 'temp',
+      default: 'visual-test-output/tmp',
+      description: 'The directory where the tmp images are saved'
+    }
+  ],
+  run(options) {
+    this.ui.writeInfoLine(`Moving changed images to ${options.imageDirectory}...`);
+
+    approveRecursively(options.diffDirectory, options.tmpDirectory, options.imageDirectory);
+
+    return options.clearTmp ? runCommand(this, 'visual-test:clean') : resolve();
+  }
+};
+
+function approveRecursively(directory, tmpDirectory, imageDirectory) {
+  fs.readdirSync(directory).forEach(function(file) {
+    let filePath = path.join(directory, file);
+    let oldPath = path.join(tmpDirectory, file);
+    let newPath = path.join(imageDirectory, file);
+
+    if (fs.lstatSync(filePath).isDirectory()) {
+      approveRecursively(filePath, oldPath, newPath);
+    } else if (file.includes('.png')) {
+      fs.renameSync(oldPath, newPath);
+    }
+  });
+}

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = {
+  'visual-test:approve': require('./approve'),
   'visual-test:clean': require('./clean'),
   'visual-test:reset': require('./reset')
 };

--- a/tests/dummy/app/templates/docs/cli.md
+++ b/tests/dummy/app/templates/docs/cli.md
@@ -1,6 +1,7 @@
 # CLI
 
-There are also two CLI commands to use: 
+There are also two CLI commands to use:
 
+* `ember visual-test:approve`: Make changed images the new baseline
 * `ember visual-test:clean`: Clean the diff/tmp folders
 * `ember visual-test:reset`: Manually clean all folders & create new baseline images

--- a/tests/dummy/app/templates/docs/cli.md
+++ b/tests/dummy/app/templates/docs/cli.md
@@ -1,6 +1,6 @@
 # CLI
 
-There are also two CLI commands to use:
+There are also three CLI commands to use:
 
 * `ember visual-test:approve`: Make changed images the new baseline
 * `ember visual-test:clean`: Clean the diff/tmp folders

--- a/tests/dummy/app/templates/docs/how.md
+++ b/tests/dummy/app/templates/docs/how.md
@@ -1,14 +1,20 @@
 # How does it work?
 
-Whenever `capture` is called in the test, the node server will make a screenshot with 
-[simple-headless-chrome](https://github.com/LucianoGanga/simple-headless-chrome), 
+Whenever `capture` is called in the test, the node server will make a screenshot with
+[simple-headless-chrome](https://github.com/LucianoGanga/simple-headless-chrome),
 and save it in the `/visual-test-output/baseline` folder. Please commit this folder into source control!
 
-Now, whenever the test is run, a new snapshot is made and put in the `/visual-test-output/tmp` folder 
-(do NOT put that into source control!). It then compares the two images with 
-[pixelmatch](https://github.com/mapbox/pixelmatch) and asserts accordingly. 
+Now, whenever the test is run, a new snapshot is made and put in the `/visual-test-output/tmp` folder
+(do NOT put that into source control!). It then compares the two images with
+[pixelmatch](https://github.com/mapbox/pixelmatch) and asserts accordingly.
 If a mismatch is found, it will save an image with the diff of the two versions in the `/visual-test-output/diff` folder, to help you identify the issue.
 
-Note that this means that if a screen changes consciously, you'll need to either manually 
-delete that image from the `/visual-test-output/baseline` folder, 
-or run `ember visual-test:reset` to reset ALL images.
+Note that this means that if a screen changes consciously, you'll need to create
+new baseline image for that screen. Here are some strategies you might want use:
+
+- manually delete the image from the `/visual-test-output/baseline` folder
+and run tests to generate new screenshot,
+- manually move the image from the `/visual-test-output/tmp` folder to
+the `/visual-test-output/baseline` folder,
+- run `ember visual-test:reset` to delete and recreate _all images_,
+- run `ember visual-test:approve` to make _all changed images_ a new baeline.

--- a/tests/dummy/app/templates/docs/how.md
+++ b/tests/dummy/app/templates/docs/how.md
@@ -17,4 +17,4 @@ and run tests to generate new screenshot,
 - manually move the image from the `/visual-test-output/tmp` folder to
 the `/visual-test-output/baseline` folder,
 - run `ember visual-test:reset` to delete and recreate _all images_,
-- run `ember visual-test:approve` to make _all changed images_ a new baeline.
+- run `ember visual-test:approve` to make _all changed images_ a new baseline.


### PR DESCRIPTION
A new CLI command: `ember visual-test:approve`. It works as described in #24 - for each file in the diff folder makes the changed image a new baseline.

The effect is somehow similar to `ember visual-test:reset`, but it doesn't rerun tests (it's much faster) and ignores changes below diff threshold.