### PR TITLE
Make visual-test:clean command recursive

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,12 +8,12 @@ const fs = require('fs');
 function deleteImagesInFolder(filePath) {
   if (fs.existsSync(filePath)) {
     fs.readdirSync(filePath).forEach(function(file) {
-      if (!file.includes('.png')) {
-        return;
-      }
-
       let curPath = path.join(filePath, file);
-      fs.unlinkSync(curPath)
+      if (fs.lstatSync(curPath).isDirectory()) {
+        deleteImagesInFolder(curPath);
+      } else if (file.includes('.png')) {
+        fs.unlinkSync(curPath)
+      }
     });
   }
 };


### PR DESCRIPTION
I've noticed that `ember visual-test:clean` doesn't work with subfolders. I suppose it should so I've made it recursive.