### PR TITLE
Modes

### DIFF
--- a/addon-test-support/helpers.js
+++ b/addon-test-support/helpers.js
@@ -21,7 +21,7 @@ import RSVP from 'rsvp';
  * @param {integer} [options.delayMs] Delay (in milliseconds) before taking the screenshot. Useful when you need to wait for CSS transitions, etc. Defaults to `100`.
  * @return {Promise}
  */
-export async function capture(assert, fileName, { selector = null, fullPage = true, delayMs = 100 } = {}) {
+export async function capture(assert, fileName, { selector = null, fullPage = true, delayMs = 100, mode = null } = {}) {
   let testId = assert.test.testId;
 
   let queryParamString = window.location.search.substr(1);
@@ -53,12 +53,12 @@ export async function capture(assert, fileName, { selector = null, fullPage = tr
   ];
 
   let url = `${window.location.protocol}//${window.location.host}${window.location.pathname}?${urlQueryParams.join('&')}`;
-  let response = await requestCapture(url, fileName, { selector, fullPage, delayMs });
+  let response = await requestCapture(url, fileName, { selector, fullPage, delayMs, mode });
 
   if (response.status === 'SUCCESS') {
-    assert.ok(true, `visual-test: ${fileName} has not changed`);
+    assert.ok(true, `visual-test: ${fileName} (${mode || 'default'}) has not changed`);
   } else {
-    assert.ok(false, `visual-test: ${fileName} has changed: ${response.error}`);
+    assert.ok(false, `visual-test: ${fileName} (${mode || 'default'}) has changed: ${response.error}`);
   }
 
   return response;
@@ -79,7 +79,7 @@ export function prepareCaptureMode() {
   }
 }
 
-export async function requestCapture(url, fileName, { selector, fullPage, delayMs }) {
+export async function requestCapture(url, fileName, { selector, fullPage, delayMs, mode }) {
   // If not in capture mode, make a request to the middleware to capture a screenshot in node
   fileName = dasherize(fileName);
 
@@ -88,7 +88,8 @@ export async function requestCapture(url, fileName, { selector, fullPage, delayM
     name: fileName,
     selector,
     fullPage,
-    delayMs
+    delayMs,
+    mode
   };
 
   return await ajaxPost('/visual-test/make-screenshot', data, 'application/json');

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -10,7 +10,12 @@ module.exports = function(defaults) {
     visualTest: {
       imageLogging: true,
       debugLogging: true,
-      imgurClientId: '6331cc0a93af83c'
+      imgurClientId: '6331cc0a93af83c',
+      modes: {
+        mobile: {
+          windowWidth: 412
+        }
+      }
     },
     fingerprint: {
       exclude: [

--- a/tests/acceptance/visual-test-test.js
+++ b/tests/acceptance/visual-test-test.js
@@ -13,6 +13,8 @@ module('Acceptance | visual test', function(hooks) {
     assert.equal(currentURL(), '/visual-test-route');
 
     await capture(assert, 'visual-test');
+
+    await capture(assert, 'visual-test', { mode: 'mobile' });
   });
 });
 // END-SNIPPET

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -13,6 +13,7 @@ Router.map(function() {
   docsRoute(this, function () {
     this.route('how');
     this.route('mirage');
+    this.route('modes');
     this.route('platforms');
     this.route('styles');
     this.route('tech');

--- a/tests/dummy/app/templates/docs.hbs
+++ b/tests/dummy/app/templates/docs.hbs
@@ -13,6 +13,7 @@
 
     {{nav.section 'Advanced'}}
     {{nav.item 'Styles' 'docs.styles'}}
+    {{nav.item 'Modes' 'docs.modes'}}
     {{nav.item 'ember-cli-mirage' 'docs.mirage'}}
     {{nav.item 'Technical explanation' 'docs.tech'}}
   {{/viewer.nav}}

--- a/tests/dummy/app/templates/docs/build.md
+++ b/tests/dummy/app/templates/docs/build.md
@@ -11,7 +11,8 @@ let app = new EmberAddon(defaults, {
    debugLogging: false, // If console messages from headless chrome should be printed in the console
    imgurClientId: null, // If set to a client ID of imgur, images will be uploaded there as well, to debug images e.g. on CI
    groupByOs: true, // If one set of images should be created/compared by OS
-   noSandbox: false // This may need to be set to true depending on your environment e.g. in CI 
+   noSandbox: false // This may need to be set to true depending on your environment e.g. in CI
+   modes: {} // Modes configuration - learn more in the modes section
   }
 });
 ```

--- a/tests/dummy/app/templates/docs/modes.md
+++ b/tests/dummy/app/templates/docs/modes.md
@@ -1,0 +1,47 @@
+# Modes
+
+If you need to test your app in multiple setups (let's say different screen sizes),
+`modes` come in handy.
+
+## Defining modes
+
+Define your modes in the `ember-cli-build.js`:
+
+```js
+let app = new EmberAddon(defaults, {
+  visualTest: {
+   // some configuration params ommited for brevity
+   windowWidth: 1024,
+   modes: {
+     tablet: {
+       windowWidth: 768
+     },
+     mobile: {
+       windowWidth: 412
+     }
+   }
+  }
+});
+```
+You can name your modes as you like - as long as they are a valid JavaScript object keys.
+
+Modes support same options as the main configuration. Learn more about configuration
+in the [build section](build).
+
+Each mode configuration will be merged with the main configuration. You can skip
+options in mode config if they stay the same as in the main config.
+
+
+## Using modes
+
+To use a mode just pass its name to the `capture()` helper like this:
+
+```js
+// this will use default config
+// and will create visual-test.png file:
+await capture(assert, 'visual-test');
+
+// this will use mobile mode config
+// and will create visual-test-mobile.png file:
+await capture(assert, 'visual-test', { mode: 'mobile' });
+```


### PR DESCRIPTION
I've got a project with responsive design which should be tested in different screen resolutions. I thought it could be useful to support multiple configurations, instead of just one resolution per whole application.

Here I've implemented something I called modes (I'm not sure if that's a good word...). Basically it does just that - allows you to define multiple configurations and then pick one in each `capture` call.

```js
// ember-cli-build.js
let app = new EmberAddon(defaults, {
  visualTest: {
   // some configuration params ommited for brevity
   windowWidth: 1024,
   modes: {
     tablet: {
       windowWidth: 768
     },
     mobile: {
       windowWidth: 412
     }
   }
  }
});
```

```js
// this will use default config
// and will create visual-test.png file:
await capture(assert, 'visual-test');

 // this will use mobile mode config
// and will create visual-test-mobile.png file:
await capture(assert, 'visual-test', { mode: 'mobile' });
```