### PR TITLE
'Skip visual tests' QUnit option

### DIFF
--- a/addon-test-support/helpers.js
+++ b/addon-test-support/helpers.js
@@ -45,6 +45,12 @@ export async function capture(assert, fileName, { selector = null, fullPage = tr
     });
   }
 
+  // if skipvisual QUnit param is true, do nothing
+  if (queryParams.includes('skipvisual')) {
+    assert.ok(true, `visual-test: ${fileName} skipped`);
+    return;
+  }
+
   // If not in capture mode, make a request to the middleware to capture a screenshot in node
   let urlQueryParams = [
     `testId=${testId}`,

--- a/addon-test-support/setup.js
+++ b/addon-test-support/setup.js
@@ -1,0 +1,22 @@
+import QUnit from 'qunit';
+
+/**
+ * Setup QUnit for visual tests
+ * It adds skip visual tests option to QUnit interface
+ * This should be called in test-helper.js before QUnit start() method
+ *
+ * ```
+ * import { start } from 'ember-qunit';
+ * import setupVisualTests from 'ember-visual-test/test-support/setup';
+ *
+ * setupVisualTests();
+ * start();
+ * ```
+ */
+export default function() {
+  QUnit.config.urlConfig.push({
+    id: 'skipvisual',
+    label: 'Skip visual tests',
+    tooltip: 'Pass all capture calls without performing them'
+  });
+}

--- a/blueprints/ember-visual-test/index.js
+++ b/blueprints/ember-visual-test/index.js
@@ -6,10 +6,24 @@ module.exports = {
   },
 
   afterInstall: function() {
-    return this.insertIntoFile('.gitignore',
-      `/visual-test-output/tmp/**/*.png
-/visual-test-output/diff/**/*.png`).then(function() {
-      return this.insertIntoFile('.npmignore', `/visual-test-output`);
-    }.bind(this))
+    return this.insertIntoFile(
+      '.gitignore',
+      '/visual-test-output/tmp/**/*.png\n/visual-test-output/diff/**/*.png'
+    ).then(() => this.insertIntoFile(
+      '.npmignore',
+      '/visual-test-output'
+    )).then(() => this.insertIntoFile(
+      'tests/test-helper.js',
+      `import setupVisualTests from 'ember-visual-test/test-support/setup';`,
+      {
+        after: `import { start } from 'ember-qunit';\n`
+      }
+    )).then(() => this.insertIntoFile(
+      'tests/test-helper.js',
+      'setupVisualTests();',
+      {
+        before: 'start()'
+      }
+    ))
   }
 };

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -2,7 +2,9 @@ import Application from '../app';
 import config from '../config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
+import setupVisualTests from 'ember-visual-test/test-support/setup';
 
 setApplication(Application.create(config.APP));
 
+setupVisualTests();
 start();


### PR DESCRIPTION
I've got a project which has a lot of visual tests. I do need them, but not always - sometimes I'd like to skip them to test things faster. So here I've added a QUnit checkbox that allows you to skip all visual tests - they will pass without performing actual tests.