### PR TITLE
Add chromeFlags option

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = {
     windowWidth: 1024,
     windowHeight: 768,
     noSandbox: false,
-    hideScrollbars: false
+    chromeFlags: []
   },
 
   included(app) {
@@ -70,13 +70,9 @@ module.exports = {
 
     let options = this.visualTest;
 
-    let flags = [
-      '--enable-logging'
-    ];
-
-    let hideScrollbars = options.hideScrollbars;
-    if (hideScrollbars) {
-      flags.push('--hide-scrollbars');
+    let flags = options.chromeFlags;
+    if (!flags.includes('--enable-logging')) {
+      flags.push('--enable-logging');
     }
 
     let noSandbox = options.noSandbox;

--- a/index.js
+++ b/index.js
@@ -70,7 +70,8 @@ module.exports = {
 
     let options = this.visualTest;
 
-    let flags = options.chromeFlags;
+    // ensure only strings are used as flags
+    let flags = options.chromeFlags.filter(flag => typeof flag === 'string' && flag);
     if (!flags.includes('--enable-logging')) {
       flags.push('--enable-logging');
     }

--- a/index.js
+++ b/index.js
@@ -33,7 +33,8 @@ module.exports = {
     chromePort: 0,
     windowWidth: 1024,
     windowHeight: 768,
-    noSandbox: false
+    noSandbox: false,
+    hideScrollbars: false
   },
 
   included(app) {
@@ -72,6 +73,11 @@ module.exports = {
     let flags = [
       '--enable-logging'
     ];
+
+    let hideScrollbars = options.hideScrollbars;
+    if (hideScrollbars) {
+      flags.push('--hide-scrollbars');
+    }
 
     let noSandbox = options.noSandbox;
     if (process.env.TRAVIS || process.env.CIRCLECI) {

--- a/tests/dummy/app/templates/docs/build.md
+++ b/tests/dummy/app/templates/docs/build.md
@@ -11,7 +11,8 @@ let app = new EmberAddon(defaults, {
    debugLogging: false, // If console messages from headless chrome should be printed in the console
    imgurClientId: null, // If set to a client ID of imgur, images will be uploaded there as well, to debug images e.g. on CI
    groupByOs: true, // If one set of images should be created/compared by OS
-   noSandbox: false // This may need to be set to true depending on your environment e.g. in CI 
+   noSandbox: false // This may need to be set to true depending on your environment e.g. in CI
+   hideScrollbars: false // If scrollbars should be hidden in screenshots
   }
 });
 ```

--- a/tests/dummy/app/templates/docs/build.md
+++ b/tests/dummy/app/templates/docs/build.md
@@ -12,7 +12,7 @@ let app = new EmberAddon(defaults, {
    imgurClientId: null, // If set to a client ID of imgur, images will be uploaded there as well, to debug images e.g. on CI
    groupByOs: true, // If one set of images should be created/compared by OS
    noSandbox: false // This may need to be set to true depending on your environment e.g. in CI
-   chromeFlags: false // Flags used when launching headless chrome
+   chromeFlags: [] // Flags used when launching headless chrome
   }
 });
 ```

--- a/tests/dummy/app/templates/docs/build.md
+++ b/tests/dummy/app/templates/docs/build.md
@@ -12,7 +12,7 @@ let app = new EmberAddon(defaults, {
    imgurClientId: null, // If set to a client ID of imgur, images will be uploaded there as well, to debug images e.g. on CI
    groupByOs: true, // If one set of images should be created/compared by OS
    noSandbox: false // This may need to be set to true depending on your environment e.g. in CI
-   hideScrollbars: false // If scrollbars should be hidden in screenshots
+   chromeFlags: false // Flags used when launching headless chrome
   }
 });
 ```


### PR DESCRIPTION
The `--hide-scrollbars` CLI switch is useful for reducing the amount of noise in visual tests.

Hiding scrollbars is what [pupeteer does by default in headless mode](https://github.com/GoogleChrome/puppeteer/blob/master/lib/Launcher.js).

These changes won't affect `ember-visual-test` default behaviour, so this shouldn't be a breaking change.